### PR TITLE
Fix invalid schema column definition

### DIFF
--- a/database/migrations/2025_02_28_183211_add_api_token_refresh_token_absent_type_to_users_table.php
+++ b/database/migrations/2025_02_28_183211_add_api_token_refresh_token_absent_type_to_users_table.php
@@ -12,8 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->text('api_token', 80)->nullable()->after('radius');
-            $table->text('refresh_token', 255)->nullable()->after('api_token');
+            $table->string('api_token', 80)->nullable()->after('radius');
+            $table->text('refresh_token')->nullable()->after('api_token');
             $table->boolean('absent_type')->default(0)->after('refresh_token');
         });
     }


### PR DESCRIPTION
## Summary
- fix `api_token` column to use `string` instead of `text` and remove invalid length param

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68405fa1ef78832994a1ea4325506857